### PR TITLE
feat: add FastAPI REST API and PDF export option

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,65 @@
+# api/main.py
+# Optional FastAPI REST API for DockLens.
+# Allows external tools to scan Docker images via HTTP requests.
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from scanner.docker_image import validate_and_pull_image
+from scanner.extractor import extract_filesystem
+from scanner.packages import extract_packages
+from vulns.scanner import scan_packages
+from cve.cpe import enrich_packages
+
+app = FastAPI(
+    title="DockLens API",
+    description="Docker Image Security Scanner REST API",
+    version="1.0.0"
+)
+
+
+class ScanRequest(BaseModel):
+    image: str
+    no_cache: bool = False
+
+
+class ScanResponse(BaseModel):
+    image: str
+    total_packages: int
+    vulnerabilities_found: int
+    findings: list
+
+
+@app.get("/")
+def root():
+    return {"message": "DockLens API is running. Use POST /scan to scan an image."}
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
+
+@app.post("/scan", response_model=ScanResponse)
+def scan(request: ScanRequest):
+    """
+    Scan a Docker image for known vulnerabilities.
+    The image must be available locally or on Docker Hub.
+    """
+    try:
+        validate_and_pull_image(request.image)
+        fs_path = extract_filesystem(request.image)
+        packages = extract_packages(str(fs_path))
+        packages = enrich_packages(packages)
+        findings = scan_packages(packages, no_cache=request.no_cache)
+
+        vulns_found = len([f for f in findings if f["severity"] != "NONE"])
+
+        return ScanResponse(
+            image=request.image,
+            total_packages=len(packages),
+            vulnerabilities_found=vulns_found,
+            findings=findings
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/cli/menu.py
+++ b/cli/menu.py
@@ -2,7 +2,7 @@
 # Main CLI entry point for DockLens.
 
 import typer
-from cli.output import show_table, show_json
+from cli.output import show_table, show_json, export_pdf
 from scanner.docker_image import validate_and_pull_image
 from scanner.extractor import extract_filesystem
 from scanner.packages import extract_packages
@@ -21,9 +21,8 @@ def main():
 def scan(
     image: str = typer.Argument(..., help="Docker image to scan"),
     format: str = typer.Option("table", help="Output format: table|json"),
-    no_cache: bool = typer.Option(
-        False, "--no-cache", help="Bypass the local vulnerability cache"
-    ),
+    no_cache: bool = typer.Option(False, "--no-cache", help="Bypass the local vulnerability cache"),
+    export: str = typer.Option(None, "--export", help="Export to file: rapport.pdf or rapport.json"),
 ):
     """
     Scan a Docker image for known vulnerabilities.
@@ -43,3 +42,13 @@ def scan(
         show_json(image, findings)
     else:
         show_table(image, findings)
+
+    if export:
+        if export.endswith(".pdf"):
+            export_pdf(image, findings, export)
+            typer.echo(f"PDF report saved: {export}")
+        elif export.endswith(".json"):
+            import json
+            with open(export, "w") as f:
+                json.dump({"image": image, "findings": findings}, f, indent=2)
+            typer.echo(f"JSON report saved: {export}")

--- a/cli/output.py
+++ b/cli/output.py
@@ -39,3 +39,45 @@ def show_json(image: str, findings: list):
         "image": image,
         "findings": findings,
     }))
+
+
+from reportlab.lib.pagesizes import A4
+from reportlab.lib import colors
+from reportlab.platypus import SimpleDocTemplate, Table as RLTable, TableStyle, Paragraph, Spacer
+from reportlab.lib.styles import getSampleStyleSheet
+
+
+def export_pdf(image: str, findings: list, output_path: str):
+    """Generate a PDF report of the scan results."""
+    doc = SimpleDocTemplate(output_path, pagesize=A4)
+    styles = getSampleStyleSheet()
+    story = []
+
+    story.append(Paragraph(f"DockLens Scan Report", styles['Title']))
+    story.append(Paragraph(f"Image: {image}", styles['Normal']))
+    story.append(Spacer(1, 12))
+
+    data = [["Package", "Version", "Severity", "CVE", "Fix", "Command"]]
+    for f in findings:
+        data.append([
+            f["package"],
+            f["version"] or "-",
+            f["severity"],
+            f.get("cve") or "-",
+            f.get("fix") or "-",
+            f.get("command") or "-",
+        ])
+
+    table = RLTable(data, colWidths=[80, 70, 60, 120, 70, 120])
+    table.setStyle(TableStyle([
+        ('BACKGROUND', (0,0), (-1,0), colors.HexColor('#16213e')),
+        ('TEXTCOLOR', (0,0), (-1,0), colors.white),
+        ('FONTNAME', (0,0), (-1,0), 'Helvetica-Bold'),
+        ('FONTSIZE', (0,0), (-1,-1), 7),
+        ('ROWBACKGROUNDS', (0,1), (-1,-1), [colors.white, colors.HexColor('#f0f4ff')]),
+        ('GRID', (0,0), (-1,-1), 0.5, colors.grey),
+        ('VALIGN', (0,0), (-1,-1), 'TOP'),
+        ('PADDING', (0,0), (-1,-1), 4),
+    ]))
+    story.append(table)
+    doc.build(story)


### PR DESCRIPTION
Added FastAPI REST API (api/main.py) with POST /scan endpoint and GET /health. Added --export option to CLI for PDF and JSON report generation